### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ CHANGES
 6.0 (unreleased)
 ----------------
 
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+
 - Add support for Python 3.12, 3.13.
 
 - Drop support for Python 3.7, 3.8.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 CHANGES
 =======
 
-5.1 (unreleased)
+6.0 (unreleased)
 ----------------
 
 - Add support for Python 3.12, 3.13.

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@
 """
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -58,7 +57,7 @@ test_requires = [
     'zope.site',
     'zope.testbrowser >= 5.2',
     'zope.testing',
-    'zope.testrunner',
+    'zope.testrunner >= 6.4',
 ]
 
 setup(name='zope.app.component',
@@ -93,9 +92,6 @@ setup(name='zope.app.component',
       ],
       url='https://github.com/zopefoundation/zope.app.component',
       license='ZPL-2.1',
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-      namespace_packages=['zope', 'zope.app'],
       python_requires='>=3.9',
       extras_require={
           'test': test_requires,

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ test_requires = [
 ]
 
 setup(name='zope.app.component',
-      version='5.1.dev0',
+      version='6.0.dev0',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.dev',
       description='Local Zope Component Support',

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover

--- a/src/zope/app/__init__.py
+++ b/src/zope/app/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
